### PR TITLE
install *.cmx files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ install-lwt:
 	mkdir -p $(DESTDIR)
 	omake clean
 	omake -j4 _build/amqp-client.cma _build/amqp-client.cmxa _build/amqp-client.a
-	cp _build/amqp-client.cma _build/amqp-client.cmxa  _build/amqp-client.a _build/*.cmt _build/*.cmi _build/*.mli $(DESTDIR)
+	cp _build/amqp-client.cma _build/amqp-client.cmxa  _build/amqp-client.a _build/*.cmt _build/*.cmi _build/*.mli _build/*.cmx $(DESTDIR)
 
 install-async: export thread=async
 install-async: DESTDIR=$(OCAMLFINDDIR)/amqp-client/$(thread)
@@ -27,7 +27,7 @@ install-async:
 	mkdir -p $(DESTDIR)
 	omake clean
 	omake -j4 _build/amqp-client.cma _build/amqp-client.cmxa _build/amqp-client.a
-	cp _build/amqp-client.cma _build/amqp-client.cmxa  _build/amqp-client.a _build/*.cmt _build/*.cmi _build/*.mli $(DESTDIR)
+	cp _build/amqp-client.cma _build/amqp-client.cmxa  _build/amqp-client.a _build/*.cmt _build/*.cmi _build/*.mli _build/*.cmx $(DESTDIR)
 
 # Determine targets to install
 LIBS := $(addprefix install-, $(shell ocamlfind list | grep -E '^(async |lwt )' | cut -d' ' -f1))


### PR DESCRIPTION
when I used this library, I found following warnings. 

<pre>
- build src/server main.o
+ ocamlfind ocamlopt -package unix,threads,amqp-client.lwt -warn-error A -thread -g -annot -bin-annot -I . -I ../share -c main.ml
File "_none_", line 1:
Warning 58: no cmx file was found in path for module Amqp, and its interface was not compiled with -opaque
File "_none_", line 1:
Warning 58: no cmx file was found in path for module Amqp_thread, and its interface was not compiled with -opaque
File "_none_", line 1:
Warning 58: no cmx file was found in path for module Amqp_connection, and its interface was not compiled with -opaque
File "_none_", line 1:
Warning 58: no cmx file was found in path for module Amqp_channel, and its interface was not compiled with -opaque
File "_none_", line 1:
Warning 58: no cmx file was found in path for module Amqp_queue, and its interface was not compiled with -opaque
File "_none_", line 1:
Warning 58: no cmx file was found in path for module Amqp_rpc, and its interface was not compiled with -opaque
File "main.ml", line 1:
</pre>


This small patch solves my problem.