### PR TITLE
Make the fatal warnings non fatal on release builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
+RELEASE = false
+
 .DEFAULT: all
 .PHONY: $(MAKECMDGOALS)
 all:
-	omake -w -j 4
+	omake -w -j 4 RELEASE=$(RELEASE)
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 RELEASE = false
+NPROC := $(shell nproc || echo 4)
+OMAKE := omake -j $(NPROC) RELEASE=$(RELEASE)
 
 .DEFAULT: all
 .PHONY: $(MAKECMDGOALS)
 all:
-	omake -w -j 4 RELEASE=$(RELEASE)
-
+	$(OMAKE) -w
 
 
 ifeq ($(MAKECMDGOALS), install)
@@ -19,16 +20,16 @@ install-lwt: export thread=lwt
 install-lwt: DESTDIR=$(OCAMLFINDDIR)/amqp-client/$(thread)
 install-lwt:
 	mkdir -p $(DESTDIR)
-	omake clean
-	omake -j4 _build/amqp-client.cma _build/amqp-client.cmxa _build/amqp-client.a
+	$(OMAKE) clean
+	$(OMAKE) _build/amqp-client.cma _build/amqp-client.cmxa _build/amqp-client.a
 	cp _build/amqp-client.cma _build/amqp-client.cmxa  _build/amqp-client.a _build/*.cmt _build/*.cmi _build/*.mli _build/*.cmx $(DESTDIR)
 
 install-async: export thread=async
 install-async: DESTDIR=$(OCAMLFINDDIR)/amqp-client/$(thread)
 install-async:
 	mkdir -p $(DESTDIR)
-	omake clean
-	omake -j4 _build/amqp-client.cma _build/amqp-client.cmxa _build/amqp-client.a
+	$(OMAKE) clean
+	$(OMAKE) _build/amqp-client.cma _build/amqp-client.cmxa _build/amqp-client.a
 	cp _build/amqp-client.cma _build/amqp-client.cmxa  _build/amqp-client.a _build/*.cmt _build/*.cmi _build/*.mli _build/*.cmx $(DESTDIR)
 
 # Determine targets to install
@@ -45,5 +46,5 @@ uninstall:
 
 else
 $(MAKECMDGOALS):
-	omake -w -j 4 $(MAKECMDGOALS)
+	$(OMAKE) -w $(MAKECMDGOALS)
 endif

--- a/OMakefile
+++ b/OMakefile
@@ -4,7 +4,18 @@ USE_OCAMLFIND = true
 NATIVE_ENABLED = true
 BYTE_ENABLED = true
 
-OCAMLFLAGS = -thread -g -w @A-4-29-41-44-45 -bin-annot
+if $(not $(defined RELEASE))
+   RELEASE=false
+   export
+
+if $(RELEASE)
+   WARNING_ERROR=
+   export
+else
+   WARNING_ERROR=@
+   export
+
+OCAMLFLAGS = -thread -g -w $(WARNING_ERROR)A-4-29-41-44-45 -bin-annot
 OCAMLPACKS[] = ocplib-endian
 
 if $(equal $(getenv thread, async), lwt)

--- a/opam
+++ b/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/andersfugmann/amqp-client"
 bug-reports: "https://github.com/andersfugmann/amqp-client/issues"
 license: "BSD3"
 dev-repo: "https://github.com/andersfugmann/amqp-client.git"
-build: [ ]
+build: [make "RELEASE=true"]
 install: [make "install"]
 remove: [make "uninstall"]
 depends: [

--- a/opam
+++ b/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/andersfugmann/amqp-client/issues"
 license: "BSD3"
 dev-repo: "https://github.com/andersfugmann/amqp-client.git"
 build: [make "RELEASE=true"]
-install: [make "install"]
+install: [make "RELEASE=true" "install"]
 remove: [make "uninstall"]
 depends: [
   "ocamlfind" {build}


### PR DESCRIPTION
The idea with fatal warning is a solid one: it is bad style to have code compiling with warnings that could be easily fixed. But on the other hand, having warnings enabled for release builds can cause issues like this time with the deprecation of the Std module, which is not a problem with code itself but rather with the environment moving forward.

Therefore this PR proposes to add a flag to the build which disables fatal warnings on release builds. This way the releases of the library are forward compatible and will not be broken by future versions of Core, Async or the OCaml compiler as easily.