### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   global:
     - PACKAGE=amqp-client
     - DEPOPTS="*"
+    - TESTS=false
   matrix:
     - OCAML_VERSION=4.03
     - OCAML_VERSION=4.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: c
+sudo: required
+install:
+  - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
+script: bash -ex .travis-opam.sh
+env:
+  global:
+    - PACKAGE=amqp-client
+    - DEPOPTS="*"
+  matrix:
+    - OCAML_VERSION=4.03
+    - OCAML_VERSION=4.04


### PR DESCRIPTION
This builds the code on Travis to make sure the code compiles on all supported OCaml compiler versions and Lwt/Async variants.

Travis needs to be set up for the repository but that is basically just flipping a switch once.