### PR TITLE
Implement timeout for waiting on RPC responses

### DIFF
--- a/lib/amqp_rpc.ml
+++ b/lib/amqp_rpc.ml
@@ -29,7 +29,10 @@ module Client = struct
           Ivar.fill var reply;
           Hashtbl.remove t.outstanding id;
           return ()
-        | exception Not_found -> failwith ("Unknown correlation id: " ^ id)
+        | exception Not_found ->
+          (* maybe such a id never existed, maybe it arrived too late so
+           * it was deleted in the meantime *)
+          return ()
       end
     | None -> failwith "No correlation id set"
 
@@ -64,7 +67,11 @@ module Client = struct
                  }
     in
     Exchange.publish t.channel ~mandatory:true ~routing_key exchange (header, body) >>= function
-    | `Ok -> Ivar.read var
+    | `Ok -> with_timeout ttl (Ivar.read var) >>= function
+      | `Timeout ->
+        Hashtbl.remove t.outstanding correlation_id;
+        return None
+      | `Result a -> return a
 
   (** Release resources *)
   let close t =

--- a/lib/amqp_thread.ml
+++ b/lib/amqp_thread.ml
@@ -21,6 +21,10 @@ let return a = return a
 let after ms = after (Core.Time.Span.of_ms ms)
 let spawn t = don't_wait_for t
 
+let with_timeout seconds deferred =
+  let duration = Core.Time.Span.of_sec (float_of_int seconds) in
+  Clock.with_timeout duration deferred
+
 module Ivar = struct
   type 'a t = 'a Ivar.t
   let create = Ivar.create

--- a/lib/amqp_thread.mli_unused
+++ b/lib/amqp_thread.mli_unused
@@ -13,6 +13,7 @@ val ( >>| ) : 'a Deferred.t -> ('a -> 'b) -> 'b Deferred.t
 val return : 'a -> 'a Deferred.t
 val after : float -> unit Deferred.t
 val spawn : unit Deferred.t -> unit
+val with_timeout : int -> 'a Deferred.t -> [ `Result of 'a | `Timeout ] Deferred.t
 
 module Ivar : sig
   type 'a t

--- a/lib_lwt/amqp_thread.ml
+++ b/lib_lwt/amqp_thread.ml
@@ -4,6 +4,12 @@ let return = Lwt.return
 let after ms = Lwt_unix.sleep (ms /. 1000.0)
 let spawn t = Lwt.ignore_result t
 
+let with_timeout seconds deferred =
+  Lwt.pick [
+    Lwt_unix.sleep (float_of_int seconds) >>| (fun () -> `Timeout);
+    deferred >>| (fun success -> `Result success)
+  ]
+
 module Ivar = struct
   type 'a state = Empty of 'a Lwt_condition.t
                 | Full of 'a


### PR DESCRIPTION
Turns out there is a possibility that the process will wait forever on a response:

1. The library does the call by publishing to the exchange and blocks the `Deferred` on `Ivar.read`
2. The answer gets lost, because maybe the other side went out to have a smoke or had a bad morning
3. The library never unblocks

This code changes it by adding a `with_timeout` modeled after how Core Async does it and implements that for the Lwt backend as well. If this timeout triggers, the `Ivar` is deleted.

Therefore in the receiving code, getting an unknown correlation ID is not an error anymore, but is ignored since it might have been a response which arrived too late.