### PR TITLE
Do not use install/remove stanzas, handled by jbuilder

### DIFF
--- a/amqp-client.opam
+++ b/amqp-client.opam
@@ -8,8 +8,6 @@ license: "BSD3"
 version: "1.1.4"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
-install: [jbuilder install]
-remove: [jbuilder uninstall]
 depends: [
   "jbuilder" {build}
   "xml-light" {build}


### PR DESCRIPTION
OPAM2 beta5 changed the way it handles unknown variables in `opam` files (https://github.com/ocaml/opam/issues/3132). Turns out the `install` and `remove` line were using `jbuilder` and its arguments in an unquoted way.

It worked before since it expanded to nothing and the `install` and `remove` were handled by the contents of `amqp-client.install` file, so to simplify, these lines can just be removed altogether.