### PR TITLE
Fix the link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ AMQP resources (exchanges, queues etc.).
 
 Channels and consumers are tagged with an id, host name, pid etc. to ease tracing on AMQP level.
 
-[Documentation for the API (http://andersfugmann.github.io/amqp-client/).
+[Documentation for the API](http://andersfugmann.github.io/amqp-client/).
 
 ### Build infrastructure
 
@@ -44,6 +44,7 @@ It is recommended to install the package though opam.
 You should choose the package matching the concurrency library that your application will use
 
 For Janestreet async: `opam install amqp-client-async`
+
 For Ocsigen Lwt: `opam install amqp-client-lwt`
 
 #### Manual build


### PR DESCRIPTION
I saw that the markup is slightly wrong and GitHub doesn't display paragraphs where paragraphs are intended so here's a PR to fix this.