### PR TITLE
Fix async queue declare

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,7 @@
-2.1.1: (unreleased)
+2.2.0: (unreleased)
 * Make Pipe.Reader / Pipe.write non-opaque for async version
 * Fix handling of on_closed if the connection is unexpectedly closed by the server.
+* Fix incorrect order when handling responses for the same message type (#32)
 
 2.1.0: (2018-10-26)
 * Use dune commands in makefile

--- a/amqp-client-async.opam
+++ b/amqp-client-async.opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/andersfugmann/amqp-client/issues"
 dev-repo: "git+https://github.com/andersfugmann/amqp-client.git"
 doc: "https://andersfugmann.github.io/amqp-client/amqp-client-async/Amqp_client_async/"
 license: "BSD3"
-version: "2.1.1"
+version: "2.2.0"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {build}
   "xml-light" {build}
-  "amqp-client" {= "2.1.1"}
+  "amqp-client" {= "2.2.0"}
   "ocplib-endian" {>= "0.6"}
   "async" {>= "v0.10.0"}
   "uri"

--- a/amqp-client-lwt.opam
+++ b/amqp-client-lwt.opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/andersfugmann/amqp-client/issues"
 dev-repo: "git+https://github.com/andersfugmann/amqp-client.git"
 doc: "https://andersfugmann.github.io/amqp-client/amqp-client-lwt/Amqp_client_lwt/"
 license: "BSD3"
-version: "2.1.1"
+version: "2.2.0"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {build}
   "xml-light" {build}
-  "amqp-client" {= "2.1.1"}
+  "amqp-client" {= "2.2.0"}
   "ocplib-endian" {>= "0.6"}
   "lwt" {>= "2.4.6"}
   "lwt_log"

--- a/amqp-client.opam
+++ b/amqp-client.opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/andersfugmann/amqp-client/issues"
 dev-repo: "git+https://github.com/andersfugmann/amqp-client.git"
 doc: "https://andersfugmann.github.io/amqp-client/"
 license: "BSD3"
-version: "2.1.1"
+version: "2.2.0"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/async/src/connection.ml
+++ b/async/src/connection.ml
@@ -2,7 +2,7 @@ open Thread
 open Amqp_client_lib
 open Spec.Connection
 
-let version = "2.1.1"
+let version = "2.2.0"
 
 let string_until c str =
   try

--- a/async/src/framing.ml
+++ b/async/src/framing.ml
@@ -194,7 +194,7 @@ let rec read_frame t close_handler =
 
 let register_method_handler (t, channel_no) message_id handler =
   let c = channel t channel_no in
-  Mlist.prepend c.method_handlers (message_id, handler)
+  Mlist.append c.method_handlers (message_id, handler)
 
 let register_content_handler (t, channel_no) class_id handler =
   let c = channel t channel_no in

--- a/async/src/queue.ml
+++ b/async/src/queue.ml
@@ -18,6 +18,7 @@ let declare channel ?(durable=false) ?(exclusive=false) ?(auto_delete=false) ?(p
               auto_delete; no_wait=false; arguments }
   in
   Declare.request channel req >>= fun rep ->
+  assert (name = rep.Declare_ok.queue);
   return { name = rep.Declare_ok.queue }
 
 let get ~no_ack channel t =

--- a/async/test/dune
+++ b/async/test/dune
@@ -6,6 +6,7 @@
                  exchange_test
                  mandatory_test
                  queue_test
+                 queue_declare_test
                  repeat
                  rpc_async_test
                  rpc_test
@@ -48,6 +49,12 @@
 (alias
  (name   integration)
  (action (run ./queue_test.exe))
+ (package amqp-client-async)
+)
+
+(alias
+ (name   integration)
+ (action (run ./queue_declare_test.exe))
  (package amqp-client-async)
 )
 

--- a/async/test/queue_declare_test.ml
+++ b/async/test/queue_declare_test.ml
@@ -19,8 +19,11 @@ let test =
   Log.info "Connection started";
   Connection.open_channel ~id:(uniq "queue.test") Channel.no_confirm connection >>= fun channel ->
   Log.info "Channel opened";
-  let queue_names = List.init 10 (fun i -> Printf.sprintf "queue.test_%d" i) in
-  let queues = List.map (declare ~channel) queue_names in
+  let queues =
+    [0;1;2;3;4;5;6;7;8;9]
+    |> List.map (fun i -> Printf.sprintf "queue.test_%d" i)
+    |> List.map (declare ~channel)
+  in
   List.fold_left (fun acc queue -> acc >>= fun acc -> queue >>= fun queue -> return (queue :: acc)) (return []) queues >>= fun queues ->
   Log.info "Queues declared";
   List.fold_left (fun acc queue -> acc >>= fun () -> Queue.delete channel queue) (return ()) queues >>= fun () ->

--- a/async/test/queue_declare_test.ml
+++ b/async/test/queue_declare_test.ml
@@ -1,0 +1,36 @@
+open Amqp
+open Thread
+
+let uniq s =
+  Printf.sprintf "%s_%d_%s" (Filename.basename Sys.argv.(0)) (Unix.getpid ()) s
+
+let handler var { Message.message = (_, body); _ } = Ivar.fill var body; return ()
+
+let declare ~channel name =
+  let queue_name = uniq name in
+  Queue.declare channel ~auto_delete:true queue_name >>= fun queue ->
+  Log.info "Created queue: %s === %s" (Queue.name queue) queue_name;
+  match Queue.name queue = queue_name with
+  | false -> failwith (Printf.sprintf "Queue name mismatch: %s != %s" (Queue.name queue) queue_name)
+  | true -> return queue
+
+let test =
+  Connection.connect ~id:(uniq "") "localhost" >>= fun connection ->
+  Log.info "Connection started";
+  Connection.open_channel ~id:(uniq "queue.test") Channel.no_confirm connection >>= fun channel ->
+  Log.info "Channel opened";
+  let queue_names = List.init 10 (fun i -> Printf.sprintf "queue.test_%d" i) in
+  let queues = List.map (declare ~channel) queue_names in
+  List.fold_left (fun acc queue -> acc >>= fun acc -> queue >>= fun queue -> return (queue :: acc)) (return []) queues >>= fun queues ->
+  Log.info "Queues declared";
+  List.fold_left (fun acc queue -> acc >>= fun () -> Queue.delete channel queue) (return ()) queues >>= fun () ->
+  Log.info "Queues deleted";
+  Channel.close channel >>= fun () ->
+  Log.info "Channel closed";
+  Connection.close connection >>| fun () ->
+  Log.info "Connection closed";
+  Scheduler.shutdown 0
+
+let _ =
+  Scheduler.go ()
+let () = Printf.printf "Done\n"

--- a/lwt/test/dune
+++ b/lwt/test/dune
@@ -5,6 +5,7 @@
 (rule (copy# ../../async/test/exchange_test.ml exchange_test.ml))
 (rule (copy# ../../async/test/mandatory_test.ml mandatory_test.ml))
 (rule (copy# ../../async/test/queue_test.ml queue_test.ml))
+(rule (copy# ../../async/test/queue_declare_test.ml queue_declare_test.ml))
 (rule (copy# ../../async/test/repeat.ml repeat.ml))
 (rule (copy# ../../async/test/rpc_async_test.ml rpc_async_test.ml))
 (rule (copy# ../../async/test/rpc_test.ml rpc_test.ml))
@@ -20,6 +21,7 @@
         exchange_test
         mandatory_test
         queue_test
+        queue_declare_test
         repeat
         rpc_async_test
         rpc_test
@@ -62,6 +64,12 @@
 (alias
  (name   integration)
  (action (run ./queue_test.exe))
+ (package amqp-client-lwt)
+)
+
+(alias
+ (name   integration)
+ (action (run ./queue_declare_test.exe))
  (package amqp-client-lwt)
 )
 


### PR DESCRIPTION
Waiters for replies for synchronous events were placed in revered order. 
This manifested itself in queue declare reassigning the wrong and unexpected name of another queue declare result, resulting in a mixup of queue names. 

The change now asserts that the queue name indeed matches the expected - and fixes the order of waiters. 

Closes #32 