### PR TITLE
Fix RPC call ttl to consistently be millisecond

### DIFF
--- a/async/src/rpc.mli
+++ b/async/src/rpc.mli
@@ -12,7 +12,7 @@ module Client :
     val init : id:string -> Connection.t -> t Deferred.t
 
     (** Make an rpc call to the exchange using the routing key and headers.
-        @param ttl is the message timeout.
+        @param ttl is the message timeout in milliseconds.
 
         To call directly to a named queue, use
         [call t Exchange.default ~routing_key:"name_of_the_queue" ~headers:[]]

--- a/async/src/thread.ml
+++ b/async/src/thread.ml
@@ -31,8 +31,8 @@ let spawn ?exn_handler t =
     | None -> t
   )
 
-let with_timeout seconds deferred =
-  let duration = Core.Time.Span.of_sec (float_of_int seconds) in
+let with_timeout milliseconds deferred =
+  let duration = Core.Time.Span.of_ms (float_of_int milliseconds) in
   Clock.with_timeout duration deferred
 
 module Ivar = struct

--- a/lwt/src/thread.ml
+++ b/lwt/src/thread.ml
@@ -9,9 +9,9 @@ let spawn ?exn_handler t = Lwt.async (fun () ->
     | None -> t
   )
 
-let with_timeout seconds deferred =
+let with_timeout milliseconds deferred =
   Lwt.pick [
-    Lwt_unix.sleep (float_of_int seconds) >>| (fun () -> `Timeout);
+    Lwt_unix.sleep (float_of_int milliseconds /. 1000.) >>| (fun () -> `Timeout);
     deferred >>| (fun success -> `Result success)
   ]
 


### PR DESCRIPTION
closes #36