### PR TITLE
Up min version of async to v0.16.0

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -18,7 +18,6 @@ jobs:
         os:
           - ubuntu-latest
         ocaml-compiler:
-          - 4.13.0
           - 4.14.0
           - 5.0.0
         concurrency:

--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,9 @@
+* Add optional `how` parameter to thread list init signature
+* async: Upgrade min required async version to v0.16.0
+* async: Replace usage of deprecated `Core.Time` with `Core.Time_float`
+
 2.3.0: (Unreleased)
+=======
 * Allow creation of internal exchanges (only useful for use with rabbitmq). Thanks hongchangwu
 * Update amqp spec
 * Remove dependency on ocplib-endian functions and bump minir required ocaml version to 4.13

--- a/amqp-client-async.opam
+++ b/amqp-client-async.opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "2.0"}
   "amqp-client" {= version}
   "ocplib-endian" {>= "0.6"}
-  "async" {>= "v0.10.0"}
+  "async" {>= "v0.16.0"}
   "uri"
 ]
 synopsis: "Amqp client library, async version"

--- a/async/src/thread.ml
+++ b/async/src/thread.ml
@@ -9,7 +9,7 @@ module Deferred = struct
     | Core.Result.Ok v -> return (`Ok v)
     | Core.Result.Error exn -> return (`Error exn)
   module List = struct
-    let init ~f n = Deferred.List.init ~f n
+    let init ?(how:[`Sequential | `Parallel] = `Parallel) ~f n = Deferred.List.init ~how:(how :> Async_kernel.Monad_sequence.how) ~f n
     let iter ?(how:[`Sequential | `Parallel] = `Parallel) ~f l = Deferred.List.iter ~how:(how :> Async_kernel.Monad_sequence.how) ~f l
   end
 
@@ -18,7 +18,7 @@ end
 let (>>=) = (>>=)
 let (>>|) = (>>|)
 let return a = return a
-let after ms = after (Core.Time.Span.of_ms ms)
+let after ms = after (Core.Time_float.Span.of_ms ms)
 let spawn ?exn_handler t =
   don't_wait_for (
     match exn_handler with
@@ -32,7 +32,7 @@ let spawn ?exn_handler t =
   )
 
 let with_timeout milliseconds deferred =
-  let duration = Core.Time.Span.of_ms (float_of_int milliseconds) in
+  let duration = Core.Time_float.Span.of_ms (float_of_int milliseconds) in
   Clock.with_timeout duration deferred
 
 module Ivar = struct

--- a/lib/thread.ml
+++ b/lib/thread.ml
@@ -5,7 +5,7 @@ module type T = sig
     val all_unit : unit t list -> unit t
     val try_with : (unit -> 'a t) -> [> `Error of exn | `Ok of 'a ] t
     module List : sig
-      val init : f:(int -> 'a t) -> int -> 'a list t
+      val init : ?how:[`Sequential | `Parallel] -> f:(int -> 'a t) -> int -> 'a list t
       val iter : ?how:[`Sequential | `Parallel] -> f:('a -> unit t) -> 'a list -> unit t
     end
   end

--- a/lwt/src/thread.ml
+++ b/lwt/src/thread.ml
@@ -61,12 +61,14 @@ module Deferred = struct
     return x
 
   module List = struct
-    let init ~f n =
+    let init ?(how:[>`Sequential | `Parallel] = `Parallel) ~f n =
       let rec inner = function
         | i when i = n -> []
         | i -> i :: inner (i + 1)
       in
-      inner 0 |> Lwt_list.map_p f
+      match how with
+      | `Sequential -> inner 0 |> Lwt_list.map_s f
+      | `Parallel -> inner 0 |> Lwt_list.map_p f
 
     let iter ?(how:[>`Sequential | `Parallel] = `Parallel) ~f l =
       match how with


### PR DESCRIPTION
There are a few breaking changes in later versions of async, so here is a PR to update amqp-client.

This will drop support for OCaml versions lower than 4.14

closes #44 