### PR TITLE
Expose  arguments on consume API

### DIFF
--- a/async/src/queue.ml
+++ b/async/src/queue.ml
@@ -50,7 +50,7 @@ type 'a consumer = { channel: 'a Channel.t;
                      writer: Message.t Pipe.Writer.t }
 
 (** Consume message from a queue. *)
-let consume ~id ?(no_local=false) ?(no_ack=false) ?(exclusive=false)
+let consume ~id ?(no_local=false) ?(no_ack=false) ?(exclusive=false) ?(arguments=[])
     ?on_cancel channel t =
   let open Spec.Basic in
   let (reader, writer) = Pipe.create () in
@@ -77,7 +77,7 @@ let consume ~id ?(no_local=false) ?(no_ack=false) ?(exclusive=false)
               no_ack;
               exclusive;
               no_wait = false;
-              arguments = [];
+              arguments;
             }
   in
   let var = Ivar.create () in

--- a/async/src/queue.mli
+++ b/async/src/queue.mli
@@ -63,6 +63,7 @@ val consume :
   ?no_local:bool ->
   ?no_ack:bool ->
   ?exclusive:bool ->
+  ?arguments:Types.table ->
   ?on_cancel:(unit -> unit) ->
   'a Channel.t ->
   t ->


### PR DESCRIPTION
I was trying to use `amqp-client` to work with rabbitmq streams (https://www.rabbitmq.com/streams.html) but was unable to set arguments on the `consume` function. The rabbitmq docs shows that this is supported by passing arguments to  `consume` but `amqp-client` doesn't currently expose this capability.

```python
channel.basicQos(100); // QoS must be specified
channel.basicConsume(
  "my-stream",
  false,
  Collections.singletonMap("x-stream-offset", "first"), // "first" offset specification
  (consumerTag, message) -> {
    // message processing
    // ...
   channel.basicAck(message.getEnvelope().getDeliveryTag(), false); // ack is required
  },
  consumerTag -> { });
```